### PR TITLE
basic state managment

### DIFF
--- a/examples/spring/src/lib.rs
+++ b/examples/spring/src/lib.rs
@@ -5,7 +5,7 @@
 
 pub use fmrs_model::prelude::*;
 
-#[derive(FmrsModel, Debug, Default)]
+#[derive(FmrsModel, Debug, Clone, Default)]
 #[fmi_version = 2]
 pub struct Spring {
     #[parameter] // Every variable below this attribute will be a parameter.

--- a/examples/spring_interface/src/lib.rs
+++ b/examples/spring_interface/src/lib.rs
@@ -3,7 +3,7 @@
 pub use fmrs_model::prelude::*;
 
 /// The model which gets an interface
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 struct SpringModel {
     mass: f64, 
     stiffness: f64,
@@ -28,7 +28,7 @@ impl SpringModel {
     }
 }
 
-#[derive(FmrsModel, Debug, Default)]
+#[derive(FmrsModel, Debug, Default, Clone)]
 #[fmi_version = 2]
 pub struct SpringInterface {
     #[parameter]

--- a/fmrs_model/src/fmi_types/fmi2.rs
+++ b/fmrs_model/src/fmi_types/fmi2.rs
@@ -8,10 +8,6 @@ use std::ffi;
 
 use crate::fmi_types::common::*;
 
-// ------------------------- Custom names for primitive types --------------------------------------
-#[allow(non_camel_case_types)]
-pub type fmi2Byte = ffi::c_char;
-
 
 // -------------------------- Custom enums ---------------------------------------------------------
 #[repr(C)]

--- a/fmrs_model/src/fmi_types/fmi3.rs
+++ b/fmrs_model/src/fmi_types/fmi3.rs
@@ -8,13 +8,6 @@ use std::ffi;
 
 use crate::fmi_types::common::*;
 
-// ------------------------- Custom names for primitive types --------------------------------------
-#[allow(non_camel_case_types)]
-pub type fmi3Byte = u8;
-#[allow(non_camel_case_types)]
-pub type fmi3Binary = *const fmi3Byte;
-
-
 // ------------------------- Custom enums ----------------------------------------------------------
 #[repr(C)]
 #[allow(non_camel_case_types)]

--- a/fmrs_model/src/unimplemented_functions/fmi2.rs
+++ b/fmrs_model/src/unimplemented_functions/fmi2.rs
@@ -3,19 +3,6 @@ use crate::fmi_types::common::*;
 
 use std::ffi;
 
-// ------------------------------- Version ---------------------------------------------------------
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "C" fn fmi2GetVersion() -> *const ffi::c_char {
-    "2.0".as_ptr() as *const ffi::c_char
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "C" fn fmi2GetTypesPlatform() -> *const ffi::c_char {
-    "default".as_ptr() as *const ffi::c_char
-}
-
 // ------------------------------- Model managment -------------------------------------------------
 #[no_mangle]
 #[allow(non_snake_case)]
@@ -35,7 +22,7 @@ pub extern "C" fn fmi2SetupExperiment(
 pub extern "C" fn fmi2Terminate(
     _instance: *mut ffi::c_void,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -43,7 +30,7 @@ pub extern "C" fn fmi2Terminate(
 pub extern "C" fn fmi2Reset(
     _instance: *mut ffi::c_void,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -51,69 +38,10 @@ pub extern "C" fn fmi2Reset(
 pub extern "C" fn fmi2CancelStep(
     _instance: *mut ffi::c_void,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
-// ------------------------------- Serialize -------------------------------------------------------
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "C" fn fmi2SerializedFMUstateSize(
-    _instance: *mut ffi::c_void,
-    _fmu_state: *mut ffi::c_void,
-    _size: *mut usize,
-) -> FmiStatus {
-    FmiStatus::Ok
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "C" fn fmi2SerializeFMUstate(
-    _instance: *mut ffi::c_void,
-    _fmu_state: *mut ffi::c_void,
-    _serialized_state: *mut ffi::c_char,
-    _size: usize,
-) -> FmiStatus {
-    FmiStatus::Ok
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "C" fn fmi2DeSerializeFMUstate(
-    _instance: *mut ffi::c_void,
-    _fmu_state: *mut ffi::c_void,
-    _serialized_state: *const ffi::c_char,
-    _size: usize,
-) -> FmiStatus {
-    FmiStatus::Ok
-}
 // ------------------------------- Getting and setting variables -----------------------------------
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "C" fn fmi2GetFMUstate(
-    _instance: *mut ffi::c_void,
-    _fmu_state: *mut ffi::c_void,
-) -> FmiStatus {
-    FmiStatus::Ok
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "C" fn fmi2SetFMUstate(
-    _instance: *mut ffi::c_void,
-    _fmu_state: *const ffi::c_void,
-) -> FmiStatus {
-    FmiStatus::Ok
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "C" fn fmi2FreeFMUstate(
-    _instance: *mut ffi::c_void,
-    _fmu_state: *mut ffi::c_void,
-) -> FmiStatus {
-    FmiStatus::Ok
-}
-
 #[no_mangle]
 #[allow(non_snake_case)]
 pub extern "C" fn fmi2SetDebugLogging(
@@ -122,7 +50,7 @@ pub extern "C" fn fmi2SetDebugLogging(
     _n_categories: usize,
     _categories: *const *const ffi::c_char,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -135,7 +63,7 @@ pub extern "C" fn fmi2GetDirectionalDerivative(
     _n_z_ref: usize,
     _dv: *mut f64,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -147,7 +75,7 @@ pub extern "C" fn fmi2SetRealInputDerivatives(
     _order: *const i32,
     _value: *const f64,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -159,7 +87,7 @@ pub extern "C" fn fmi2GetRealOutputDerivatives(
     _order: *const i32,
     _value: *mut f64,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -169,7 +97,7 @@ pub extern "C" fn fmi2GetStatus(
     _status_kind: fmi2StatusKind,
     _value: *mut FmiStatus,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -179,7 +107,7 @@ pub extern "C" fn fmi2GetRealStatus(
     _status_kind: fmi2StatusKind,
     _value: *mut f64,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -189,7 +117,7 @@ pub extern "C" fn fmi2GetIntegerStatus(
     _status_kind: fmi2StatusKind,
     _value: *mut i32,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -199,7 +127,7 @@ pub extern "C" fn fmi2GetBooleanStatus(
     _status_kind: fmi2StatusKind,
     _value: *mut bool,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -209,5 +137,5 @@ pub unsafe extern "C" fn fmi2GetStringStatus(
     _status_kind: fmi2StatusKind,
     _value: *mut *const ffi::c_char,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }

--- a/fmrs_model/src/unimplemented_functions/fmi3.rs
+++ b/fmrs_model/src/unimplemented_functions/fmi3.rs
@@ -1,15 +1,7 @@
 use crate::fmi_types::fmi3::*;
 use crate::fmi_types::common::*;
 
-use libc;
 use std::ffi;
-
-// ------------------------------- Version ---------------------------------------------------------
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "C" fn fmi3GetVersion() -> *const ffi::c_char {
-    "3.0".as_ptr() as *const ffi::c_char
-}
 
 // ------------------------------- Model management ------------------------------------------------
 #[no_mangle]
@@ -46,58 +38,38 @@ pub extern "C" fn fmi3InstantiateScheduledExecution(
 #[no_mangle]
 #[allow(non_snake_case)]
 pub extern "C" fn fmi3EnterEventMode(_instance: *mut ffi::c_void) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
 #[allow(non_snake_case)]
 pub extern "C" fn fmi3Terminate(_instance: *mut ffi::c_void) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
 #[allow(non_snake_case)]
 pub extern "C" fn fmi3Reset(_instance: *mut ffi::c_void) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
 #[allow(non_snake_case)]
 pub extern "C" fn fmi3EnterConfigurationMode(_instance: *mut ffi::c_void) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
 #[allow(non_snake_case)]
 pub extern "C" fn fmi3ExitConfigurationMode(_instance: *mut ffi::c_void) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "C" fn fmi3FreeFMUState(
-    _instance: *mut ffi::c_void,
-    FMUstate: *mut *mut ffi::c_void,
-) -> FmiStatus {
-    if FMUstate == std::ptr::null_mut() {
-        return FmiStatus::Error;
-    }
-
-    unsafe {
-        libc::free(FMUstate as *mut libc::c_void);
-
-        *FMUstate = std::ptr::null_mut();
-    }
-
-    FmiStatus::Ok
-}
-
 
 // ------------------------------- Co-simulation ---------------------------------------------------
 #[no_mangle]
 #[allow(non_snake_case)]
 pub extern "C" fn fmi3EnterStepMode(_instance: *mut ffi::c_void) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -110,7 +82,7 @@ pub extern "C" fn fmi3GetOutputDerivatives(
     _values: *mut f64,
     _nValues: usize,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -120,14 +92,14 @@ pub extern "C" fn fmi3ActivateModelPartition(
     _clockReference: u32,
     _activationTime: f64,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 // --------------------------- Model Exchange ------------------------------------------------------
 #[no_mangle]
 #[allow(non_snake_case)]
 pub extern "C" fn fmi3EnterContinuousTimeMode(_instance: *mut ffi::c_void) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -138,7 +110,7 @@ pub extern "C" fn fmi3CompletedIntegratorStep(
     _enterEventMode: *mut bool,
     _terminateSimulation: *mut bool,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -147,7 +119,7 @@ pub extern "C" fn fmi3SetTime(
     _instance: *mut ffi::c_void,
     _time: f64,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -157,7 +129,7 @@ pub extern "C" fn fmi3SetContinuousStates(
     _continousStates: *const f64,
     _nContinuousStates: usize,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -167,7 +139,7 @@ pub extern "C" fn fmi3GetContinuousStateDerivatives(
     _derivatives: *mut f64,
     _nContinuousStates: usize,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -177,7 +149,7 @@ pub extern "C" fn fmi3GetEventIndicators(
     _eventIndicators: *mut f64,
     _nEventIndicators: usize,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -187,7 +159,7 @@ pub extern "C" fn fmi3GetContinuousStates(
     _continousStates: *mut f64,
     _nContinuousStates: usize,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -197,7 +169,7 @@ pub extern "C" fn fmi3GetNominalsOfContinuousStates(
     _nominals: *mut f64,
     _nContinuousStates: usize,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -206,7 +178,7 @@ pub extern "C" fn fmi3GetNumberOfEventIndicators(
     _instance: *mut ffi::c_void,
     _nEventIndicators: *mut usize,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -215,40 +187,7 @@ pub extern "C" fn fmi3GetNumberOfContinuousStates(
     _instance: *mut ffi::c_void,
     _nContinuousStates: *mut usize,
 ) -> FmiStatus {
-    FmiStatus::Ok
-}
-
-// --------------------------- Serialize -----------------------------------------------------------
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "C" fn fmi3SerializedFMUStateSize(
-    _instance: *mut ffi::c_void,
-    _FMUState: *mut ffi::c_void,
-    _size: *mut usize
-) -> FmiStatus {
-    FmiStatus::Ok
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "C" fn fmi3SerializeFMUState(
-    _instance: *mut ffi::c_void,
-    _FMUState: *mut ffi::c_void,
-    _serializedState: *mut fmi3Byte,
-    _size: usize
-) -> FmiStatus {
-    FmiStatus::Ok
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "C" fn fmi3DeserializeFMUState(
-    _instance: *mut ffi::c_void,
-    _serializedState: *const fmi3Byte,
-    _size: usize,
-    _FMUState: *mut *mut ffi::c_void
-) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 // --------------------------- Discrete states -----------------------------------------------------
@@ -257,7 +196,7 @@ pub extern "C" fn fmi3DeserializeFMUState(
 pub extern "C" fn fmi3EvaluateDiscreteStates(
     _instance: *mut ffi::c_void,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -271,7 +210,7 @@ pub extern "C" fn fmi3UpdateDiscreteStates(
     _nextEventTimeDefined: *mut bool,
     _nextEventTime: *mut f64,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 // -------------------------- Set and get ----------------------------------------------------------
@@ -281,11 +220,11 @@ pub unsafe extern "C" fn fmi3GetBinary(
     _instance: *mut ffi::c_void,
     _valueReferences: *const u32,
     _nValueReferences: usize,
-    _values: *mut fmi3Binary,
+    _values: *mut *const u8,
     _nValues: usize,
     _sizes: *mut usize,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -295,7 +234,7 @@ pub unsafe extern "C" fn fmi3GetClock(
     _valueReferences: *const u32,
     _values: *mut bool,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -305,7 +244,7 @@ pub extern "C" fn fmi3GetNumberOfVariableDependencies(
     _valueReference: u32,
     _nDependencies: *mut usize,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -319,16 +258,7 @@ pub extern "C" fn fmi3GetVariableDependencies(
     _dependencyKinds: *mut fmi3DependencyKind,
     _nDependencies: usize,
 ) -> FmiStatus {
-    FmiStatus::Ok
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "C" fn fmi3GetFMUState(
-    _instance: *mut ffi::c_void,
-    _FMUState: *mut *mut ffi::c_void,
-) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -344,7 +274,7 @@ pub extern "C" fn fmi3GetDirectionalDerivative(
     _sensitivity: *mut f64,
     _nSensitivity: usize,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -360,7 +290,7 @@ pub extern "C" fn fmi3GetAdjointDerivative(
     _sensitivity: *mut f64,
     _nSensitivity: usize,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -372,7 +302,7 @@ pub extern "C" fn fmi3GetIntervalDecimal(
     _interval: *mut f64,
     _qualifiers: *mut fmi3IntervalQualifier
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -384,7 +314,7 @@ pub extern "C" fn fmi3GetIntervalFraction(
     _interval: *mut f64,
     _qualifiers: *mut fmi3IntervalQualifier
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 
@@ -396,7 +326,7 @@ pub extern "C" fn fmi3GetShiftDecimal(
     _nValueReferences: usize,
     _shifts: *mut f64,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -408,7 +338,7 @@ pub extern "C" fn fmi3GetShiftFraction(
     _shiftCounters: *mut u64,
     _resolutions: *mut u64
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -419,7 +349,7 @@ pub extern "C" fn fmi3SetDebugLogging(
     _nCategories: usize,
     _categories: *const *const ffi::c_char,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -428,10 +358,10 @@ pub extern "C" fn fmi3SetBinary(
     _instance: *mut ffi::c_void,
     _valueReferences: *const u32,
     _nValueReferences: usize,
-    _values: *const fmi3Binary,
+    _values: *const *const u8,
     _nValues: usize,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -441,16 +371,7 @@ pub extern "C" fn fmi3SetClock(
     _valueReferences: *const u32,
     _values: *const bool,
 ) -> FmiStatus {
-    FmiStatus::Ok
-}
-
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "C" fn fmi3SetFMUState(
-    _instance: *mut ffi::c_void,
-    _FMUState: *mut ffi::c_void
-) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -461,7 +382,7 @@ pub extern "C" fn fmi3SetIntervalDecimal(
     _nValueReferences: usize,
     _intervals: *const f64,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -473,7 +394,7 @@ pub extern "C" fn fmi3SetIntervalFraction(
     _intervalCounters: *const u64,
     _resolutions: *const u64
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -484,7 +405,7 @@ pub extern "C" fn fmi3SetShiftDecimal(
     _nValueReferences: usize,
     _shifts: *const f64,
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }
 
 #[no_mangle]
@@ -496,5 +417,5 @@ pub extern "C" fn fmi3SetShiftFraction(
     _shiftCounters: *const u64,
     _resolutions: *const u64
 ) -> FmiStatus {
-    FmiStatus::Ok
+    FmiStatus::Error
 }

--- a/fmrs_model_derive/src/fmi_version.rs
+++ b/fmrs_model_derive/src/fmi_version.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum FmiVersion {
     Fmi2,
     Fmi3,

--- a/fmrs_model_derive/src/model_description.rs
+++ b/fmrs_model_derive/src/model_description.rs
@@ -83,19 +83,38 @@ pub fn generate_model_description(fmi_version: FmiVersion, name: &str, fields: &
                 )?;
             },
             FmiVersion::Fmi3 => {
-                write!(
-                    file, 
-                    "    <{} name=\"{}\" valueReference=\"{}\" causality=\"{}\" variability=\"{}\" initial=\"exact\" start=\"{}\"/>\n", 
-                    FieldInformation::get_fmi_type_name(fmi_version, &field.field_type), 
-                    field.name,
-                    field.value_reference,
-                    field.causality.as_string(),
-                    field.causality.variability_string(),
-                    FieldInformation::get_default_start_value_string(&field.field_type),
-                )?;
+                match field.field_type.to_string().as_str() {
+                    "String" => {
+                        write!(
+                            file, 
+                            "    <String name=\"{}\" valueReference=\"{}\" causality=\"{}\" variability=\"{}\" initial=\"exact\">\n", 
+                            field.name,
+                            field.value_reference,
+                            field.causality.as_string(),
+                            field.causality.variability_string(),
+                        )?;
+
+                        write!(
+                            file,
+                            "        <Start value=\"{}\"/>\n    </String>\n",
+                            FieldInformation::get_default_start_value_string(&field.field_type),
+                        )?;
+                    },
+                    _ => {
+                        write!(
+                            file, 
+                            "    <{} name=\"{}\" valueReference=\"{}\" causality=\"{}\" variability=\"{}\" initial=\"exact\" start=\"{}\"/>\n", 
+                            FieldInformation::get_fmi_type_name(fmi_version, &field.field_type), 
+                            field.name,
+                            field.value_reference,
+                            field.causality.as_string(),
+                            field.causality.variability_string(),
+                            FieldInformation::get_default_start_value_string(&field.field_type),
+                        )?;
+                    }
+                }
             },
         }
-        
     }
 
     write!(file, "</ModelVariables>\n\n")?;

--- a/fmrs_model_derive/src/state_management.rs
+++ b/fmrs_model_derive/src/state_management.rs
@@ -1,0 +1,181 @@
+//! Functionality to manage the "FMU state" (currently not implemented properly, all functions only
+//! returns errors...)
+//! 
+//! The FMU state is ment to allow for restart of a simulation from a given point. Examples can be 
+//! that a "do_step" call fails, and the FMU must be rolled back to the state before the call, in
+//! order to try again / try something different.
+//! 
+//! A state is not explcitly defined in the standard, but any data necessary to achive the above 
+//! goal must somehow be copied from the model instance. The details of how this is done is decided 
+//! in the set and get state functions.
+//! 
+//! In addtion, the states should be serializable as bytes.
+//! 
+//! WARNING: Not sure how to deal with memory in between setting and getting the state. Should the
+//! previous state be freed before a new state is stored? Or should the state be copied? Is it
+//! necessary to deal with varying sizes of the state?
+//! 
+//! These functions should not be called unless the feature is enabled in the modelExchange file 
+//! (which it is not for this crate).
+
+use proc_macro2::TokenStream as TokenStream2;
+
+use quote::quote;
+use syn;
+
+use super::fmi_version::FmiVersion;
+
+pub fn impl_state_managment(fmi_version: FmiVersion, structure_name: &syn::Ident) -> TokenStream2 {
+    let get_state_tokens  = impl_get_state(fmi_version, structure_name);
+    let set_state_tokens  = impl_set_state(fmi_version, structure_name);
+    let free_state_tokens = impl_free_state(fmi_version, structure_name);
+    let serialize_state_tokens = impl_serialize_state(fmi_version, structure_name);
+    let deserialize_state_tokens = impl_deserialize_state(fmi_version, structure_name);
+    let serialized_state_size_tokens = impl_serialized_state_size(fmi_version, structure_name);
+
+    quote! {
+        #get_state_tokens
+        #set_state_tokens
+        #serialize_state_tokens
+        #deserialize_state_tokens
+        #serialized_state_size_tokens
+        #free_state_tokens
+    }
+}
+
+fn impl_get_state(fmi_version: FmiVersion, _structure_name: &syn::Ident) -> TokenStream2 {
+    let function_name = match fmi_version {
+        FmiVersion::Fmi2 => quote! { fmi2GetFMUstate },
+        FmiVersion::Fmi3 => quote! { fmi3GetFMUState },
+    };
+
+    quote! {
+        #[no_mangle]
+        #[allow(non_snake_case)]
+        pub unsafe extern "C" fn #function_name(
+            instance_ptr: *const ffi::c_void,
+            state_ptr: *mut *mut ffi::c_void,
+        ) -> FmiStatus {
+            FmiStatus::Error
+        }
+    }
+}
+
+fn impl_set_state(fmi_version: FmiVersion, _strcuture_name: &syn::Ident) -> TokenStream2 {
+    let function_name = match fmi_version {
+        FmiVersion::Fmi2 => quote! { fmi2SetFMUstate },
+        FmiVersion::Fmi3 => quote! { fmi3SetFMUState },
+    };
+
+    quote! {
+        #[no_mangle]
+        #[allow(non_snake_case)]
+        pub unsafe extern "C" fn #function_name(
+            instance_ptr: *mut ffi::c_void,
+            state_ptr: *mut ffi::c_void,
+        ) -> FmiStatus {
+            FmiStatus::Error
+        }
+    }
+}
+
+fn impl_free_state(fmi_version: FmiVersion, _structure_name: &syn::Ident) -> TokenStream2 {    
+    let function_signature = match fmi_version {
+        FmiVersion::Fmi2 => quote! { 
+            fmi2FreeFMUstate(instance_ptr: *const ffi::c_void, state_ptr: *mut ffi::c_void) -> FmiStatus 
+        },
+        FmiVersion::Fmi3 => quote! {
+            fmi3FreeFMUState(instance_ptr: *const ffi::c_void, state_ptr: *mut *mut ffi::c_void) -> FmiStatus
+        },
+    };
+    
+    quote! {
+        #[no_mangle]
+        #[allow(non_snake_case)]
+        pub unsafe extern "C" fn #function_signature {
+            FmiStatus::Error
+        }
+    }
+}
+
+fn impl_serialize_state(fmi_version: FmiVersion, _structure_name: &syn::Ident) -> TokenStream2 {
+    let serialize_function_name = match fmi_version {
+        FmiVersion::Fmi2 => quote! { fmi2SerializeFMUstate },
+        FmiVersion::Fmi3 => quote! { fmi3SerializeFMUState },
+    };
+
+    let serialized_state_type = match fmi_version {
+        FmiVersion::Fmi2 => quote! { *mut ffi::c_char },
+        FmiVersion::Fmi3 => quote! { *mut u8 },
+    };
+
+    quote! {
+        #[no_mangle]
+        #[allow(non_snake_case)]
+        pub unsafe extern "C" fn #serialize_function_name(
+            instance_ptr: *mut ffi::c_void,
+            state_ptr: *mut ffi::c_void,
+            serialized_state: #serialized_state_type,
+            size: usize,
+        ) -> FmiStatus {
+            FmiStatus::Error
+        }
+    }
+}
+
+fn impl_deserialize_state(fmi_version: FmiVersion, _structure_name: &syn::Ident) -> TokenStream2 {
+    let serialized_state_type = match fmi_version {
+        FmiVersion::Fmi2 => quote! { *const ffi::c_char },
+        FmiVersion::Fmi3 => quote! { *const u8 },
+    };
+
+    let function_signature = match fmi_version {
+        FmiVersion::Fmi2 => {
+            quote! {
+                fmi2DeSerializeFMUstate(
+                    instance_ptr: *mut ffi::c_void,
+                    state_ptr: *mut ffi::c_void,
+                    serialized_state: #serialized_state_type,
+                    size: usize,
+                )
+            }
+        },
+        FmiVersion::Fmi3 => {
+            quote! {
+                fmi3DeserializeFMUState(
+                    instance_ptr: *mut ffi::c_void,
+                    serialized_state: #serialized_state_type,
+                    size: usize,
+                    state_ptr: *mut *mut ffi::c_void,
+                )
+            }
+        }
+    };
+
+    quote! {
+        #[no_mangle]
+        #[allow(non_snake_case)]
+        pub extern "C" fn #function_signature -> FmiStatus {
+            FmiStatus::Error
+        }
+    }
+}
+
+fn impl_serialized_state_size(fmi_version: FmiVersion, _structure_name: &syn::Ident) -> TokenStream2 {
+    let function_name = match fmi_version {
+        FmiVersion::Fmi2 => quote! { fmi2SerializedFMUstateSize },
+        FmiVersion::Fmi3 => quote! { fmi3SerializedFMUStateSize },
+    };
+
+    quote! {
+        #[no_mangle]
+        #[allow(non_snake_case)]
+        pub extern "C" fn #function_name(
+            instance_ptr: *mut ffi::c_void,
+            state_ptr: *mut ffi::c_void,
+            size: *mut usize,
+        ) -> FmiStatus {
+            FmiStatus::Error
+        }
+    }
+}


### PR DESCRIPTION
Added functions for state management, that currently only returns an error if they are called. They should not be necessary for basic use cases, and should also never be called as long as the features are not turned on the model exchange file